### PR TITLE
[Fix]通知に該当するコメント、いいねを削除した際のエラーを解消

### DIFF
--- a/app/controllers/public/episodes_controller.rb
+++ b/app/controllers/public/episodes_controller.rb
@@ -6,7 +6,7 @@ class Public::EpisodesController < ApplicationController
   def index
     following_user_ids = current_user.following.pluck(:id)
     @episodes_following = Episode.where(user_id: following_user_ids).order("created_at DESC").limit(10)
-    @episodes = Episode.where(visibility: 0).order("RANDOM()").limit(40).page(params[:page]).per(5)
+    @episodes = Episode.where(visibility: 0).order("RAND()").limit(40).page(params[:page]).per(5)
     @categories = Category.all
   end
 

--- a/app/controllers/public/episodes_controller.rb
+++ b/app/controllers/public/episodes_controller.rb
@@ -6,7 +6,7 @@ class Public::EpisodesController < ApplicationController
   def index
     following_user_ids = current_user.following.pluck(:id)
     @episodes_following = Episode.where(user_id: following_user_ids).order("created_at DESC").limit(10)
-    @episodes = Episode.where(visibility: 0).order("RAND()").limit(40).page(params[:page]).per(5)
+    @episodes = Episode.where(visibility: 0).order("RANDOM()").limit(40).page(params[:page]).per(5)
     @categories = Category.all
   end
 

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -3,5 +3,5 @@ class ApplicationJob < ActiveJob::Base
   # retry_on ActiveRecord::Deadlocked
 
   # Most jobs are safe to ignore if the underlying records are no longer available
-  # discard_on ActiveJob::DeserializationError
+  #discard_on ActiveJob::DeserializationError
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,7 +1,10 @@
 class Comment < ApplicationRecord
   belongs_to :episode
   belongs_to :user
-
+  
+  # 関連するnotificationを削除するためのメソッド
+  has_noticed_notifications
+  
   with_options presence: true do
     validates :content
   end

--- a/app/models/favourite.rb
+++ b/app/models/favourite.rb
@@ -2,6 +2,9 @@ class Favourite < ApplicationRecord
   belongs_to :user
   belongs_to :episode
   
+  # 関連するnotificationを削除するためのメソッド
+  has_noticed_notifications
+  
   with_options presence: true do
     validates :user_id
     validates :episode_id

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -2,6 +2,9 @@ class Relationship < ApplicationRecord
   belongs_to :follower, class_name: "User"
   belongs_to :followed, class_name: "User"
   
+  # 関連するnotificationを削除するためのメソッド
+  has_noticed_notifications
+  
   with_options presence: true do
     validates :follower_id
     validates :followed_id


### PR DESCRIPTION
# [Fix] "通知エラーを解消"
- 通知元のデータが削除された際に通知データが削除されていなかったエラーを解消